### PR TITLE
Parse boolean bug #3

### DIFF
--- a/lib/xmltojson.js
+++ b/lib/xmltojson.js
@@ -183,7 +183,7 @@ var xmlToJSON = {};
                 if (sCollectedTxt) {
                         if (options.grokText) {
                                 value = grokType(sCollectedTxt.replace(trimMatch, ''));
-                                if (value !== null || value !== undefined) {
+                                if (value !== null && value !== undefined) {
 									vResult[options.textKey] = value;
 								}
                         } else if (options.normalize) {


### PR DESCRIPTION
With the groktext option set to true, while parsing an XML, 'false' values are returned as empty strings in JSON.

In xmltojson.js it looks like line 186 is where the problem happens. When a false value is encountered the groktype function returns a boolean false resulting in 'if (value)' to be false and then an empty string is returned instead of the boolean value, false.
