### PR TITLE
Add package.json, xmlToJSON in own scope

### DIFF
--- a/lib/xmlToJSON.js
+++ b/lib/xmlToJSON.js
@@ -17,7 +17,6 @@
  * @author William Summers
  *
  */
- module.exports = xmlToJSON
  
 var xmlToJSON = (function () {
 
@@ -237,7 +236,7 @@ var xmlToJSON = (function () {
     }
 
     return this;
-})();
+}).call({});
 
 if (typeof module != "undefined" && module !== null && module.exports) module.exports = xmlToJSON;
 else if (typeof define === "function" && define.amd) define(function() {return xmlToJSON});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "xmlToJSON",
+  "version": "1.3.1",
+  "description": "Configurable, lightweight XML to JSON converter.",
+  "main": "./lib/xmlToJSON.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "open test/SpecRunner.html"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/metatribal/xmlToJSON.git"
+  },
+  "keywords": [
+    "xml",
+    "convert",
+    "transform",
+    "json"
+  ],
+  "author": "metatribal",
+  "license": "Apache",
+  "bugs": {
+    "url": "https://github.com/metatribal/xmlToJSON/issues"
+  },
+  "homepage": "https://github.com/metatribal/xmlToJSON"
+}


### PR DESCRIPTION
Interesting repo, too bad the latest version didn't work out of the box in node.js. This pr resolves that. 

I added a package.json because I was considering adding the repo as dependency in my package.json. But no clear browser tests, no updated npm repo and a broken lib are too many bad signs for me. Regardless, here it is in case you're interested. 