### PR TITLE
Ignore test folder in bower installations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,11 @@
   "name": "xmlToJSON.js",
   "version": "1.3.2",
   "main": "./lib/xmlToJSON.js",
-  "dependencies": {
-  }
+  "dependencies": {},
+  "ignore": [
+    "*",
+    "!lib/*",
+    "!LICENSE",
+    "!README.md"
+  ]
 }


### PR DESCRIPTION
When submitting an extension to [AMO](https://addons.mozilla.org/en-US/firefox/) that contains xmlToJSON, the following warnings will be thrown:

![err](https://cloud.githubusercontent.com/assets/8310677/13319379/993edc12-dbc1-11e5-9bec-5ee558a9f945.png)
![err2](https://cloud.githubusercontent.com/assets/8310677/13319381/99596492-dbc1-11e5-8d14-72a3f1f62295.png)
![err3](https://cloud.githubusercontent.com/assets/8310677/13319383/995c1a5c-dbc1-11e5-8005-72f9b05a2e49.png)
![err4](https://cloud.githubusercontent.com/assets/8310677/13319382/995985ee-dbc1-11e5-890a-f85bb2c56f30.png)
![err5](https://cloud.githubusercontent.com/assets/8310677/13319380/99593a62-dbc1-11e5-9316-c1e0eff20282.png)

Everything except the license, the README.md and the actual library is unnecessary for bower installations.
